### PR TITLE
change API call to /list instead of /list2

### DIFF
--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -1,6 +1,6 @@
 $(document).ready(function() {
     $.ajax({
-        url: "https://fff-api.dmho.de/v1/scrape/list2"
+        url: "https://fff-api.dmho.de/v1/scrape/list"
     }).then(function(data) {
         var msg = '<a href="https://fridaysforfuture.de/streiktermine/">Kein Streik geplant</a>';
         for (var entry of data["list"]) {


### PR DESCRIPTION
I think it would be better to use the list for the current week instead of the next week. @ccauet 